### PR TITLE
Update deprecated cmake version

### DIFF
--- a/edisonLibmogiPackage/libmogi/CMakeLists.txt
+++ b/edisonLibmogiPackage/libmogi/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 2.8 FATAL_ERROR)
+cmake_minimum_required(VERSION 2.12 FATAL_ERROR)
+cmake_policy(SET CMP0048 NEW)
 
 if(APPLE)
 	set(CMAKE_MACOSX_RPATH 1)


### PR DESCRIPTION
cmake 2.8 is deprecated and this line throws an error for me with my tool chain (gcc 11.2.1 20220115, cmake 3.22.2, ninja 1.10.2)